### PR TITLE
[UPD] A default value was set for the PaginationRequest's "SortBy" parameter

### DIFF
--- a/Domain/DTOs/Pagination/PaginationRequest.cs
+++ b/Domain/DTOs/Pagination/PaginationRequest.cs
@@ -5,11 +5,19 @@ namespace Domain.DTOs.Pagination
 {
     public class PaginationRequest
     {
-        [RangeField(1, int.MaxValue/GlobalConstants.MAX_PAGE_SIZE)]
+        [RangeField(1, int.MaxValue / GlobalConstants.MAX_PAGE_SIZE)]
         public int Page { get; set; } = 1;
         [RangeField(1, GlobalConstants.MAX_PAGE_SIZE)]
         public int PageSize { get; set; } = GlobalConstants.DEFAULT_PAGE_SIZE_10;
-        public string SortBy { get; set; } = GlobalConstants.DEFAULT_SORT_BY_ID;
+        public string SortBy
+        {
+            get { return _sortBy; }
+            set { _sortBy = value ?? _sortBy; }
+        }
         public bool IsSortDescendent { get; set; } = false;
+        
+        //This field is not accessible from requests.
+        private string _sortBy = GlobalConstants.DEFAULT_SORT_BY_ID;
     }
 }
+


### PR DESCRIPTION
When the 'SortBy' parameter is sent as null, the PaginationRequest takes the "Id" default value for this parameter.